### PR TITLE
Fix compatibility with Firefox and IE

### DIFF
--- a/nerdlets/nr1-command-center-nerdlet/alarms.js
+++ b/nerdlets/nr1-command-center-nerdlet/alarms.js
@@ -144,8 +144,8 @@ export default class Alarms extends React.Component {
   }
 
   checkDomain() {
-    let oneDomain = window.location.ancestorOrigins[0]
-    if (oneDomain.includes("eu")) {
+    let oneDomain = window.location.href
+    if (oneDomain.startsWith("https://one.eu.newrelic")) {
       return 'https://api.eu.newrelic.com/v2/alerts_violations.json?only_open=true';
     } else {
       return 'https://api.newrelic.com/v2/alerts_violations.json?only_open=true';


### PR DESCRIPTION
I'm not sure why using `location.ancestorOrigins` is necessary, considering that:

1) It's not compatible with Firefox. (for good reason)
2) Will be empty & crash if you directly load the page anyway.

I assume that this will always be rendered through NR1 so I don't see any downside to using `location.href`.